### PR TITLE
Curate AIFFEL coursework as an applied deep learning portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,56 @@
+# AIFFEL Applied Deep Learning Portfolio
 
-# AIFFEL_quest_rs Repository Structure
+> **Category:** Structured training portfolio  
+> **Program:** AIFFEL Research Program, October 2024–April 2025  
+> **Scope:** Machine learning, computer vision, natural language processing, and deep learning experiments
 
-```bash
-AIFFEL_quest_rs
-├── MainQuest
-│   ├── Quest01
-│   │   ├── Quest01.ipynb
-│   │   └── README.md
-│   ├── Quest02
-│   │   ├── Quest02.ipynb
-│   │   └── README.md
-│   ├── Quest03
-│   │   ├── Quest03.ipynb
-│   │   └── README.md
-│   ├── Quest04
-│   │   ├── Quest04.ipynb
-│   │   └── README.md
-│   └── Quest05
-│       ├── Quest05.ipynb
-│       └── README.md
-├── Exploration
-│   ├── Ex01
-│   │   ├── Ex01.ipynb
-│   │   └── README.md
-│   ├── Ex02
-│   │   ├── Ex02.ipynb
-│   │   └── README.md
-│   ├── Ex03
-│   │   ├── Ex03.ipynb
-│   │   └── README.md
-│   ├── Ex04
-│   │   ├── Ex04.ipynb
-│   │   └── README.md
-│   ├── Ex05
-│   │   ├── Ex05.ipynb
-│   │   └── README.md
-│   ├── Ex06
-│   │   ├── Ex06.ipynb
-│   │   └── README.md
-│   └── Ex07
-│       ├── Ex07.ipynb
-│       └── README.md
-└── GoingDeeper
-    ├── GD01
-    │   ├── GD01.ipynb
-    │   └── README.md
-    ├── GD02
-    │   ├── GD02.ipynb
-    │   └── README.md
-    ├── GD03
-    │   ├── GD03.ipynb
-    │   └── README.md
-    ├── GD04
-    │   ├── GD04.ipynb
-    │   └── README.md
-    ├── GD05
-    │   ├── GD05.ipynb
-    │   └── README.md
-    ├── GD06
-    │   ├── GD06.ipynb
-    │   └── README.md
-    ├── GD07
-    │   ├── GD07.ipynb
-    │   └── README.md
-    ├── GD08
-    │   ├── GD08.ipynb
-    │   └── README.md
-    └── GD09
-        ├── GD09.ipynb
-        └── README.md
-```
+This repository documents the breadth of models, experiments, debugging, and peer review completed during the AIFFEL Research Program. It is presented as **training evidence**, not as peer-reviewed research or a clinically validated system.
 
+AIFFEL Research 과정에서 수행한 머신러닝·딥러닝 실험을 주제별로 정리한 포트폴리오입니다. 과정 제공 baseline, 개인 구현, 팀 작업 및 peer review를 구분하며, 검증되지 않은 성능이나 임상적 효용을 주장하지 않습니다.
+
+## Why this portfolio
+
+My background combines CT systems engineering and quantitative chest-CT research. I used the AIFFEL program to strengthen practical implementation across data science, computer vision, segmentation, explainability, detection, sequence modeling, and Transformer architectures. These projects support—but do not replace—my clinical-imaging research record.
+
+## Curriculum navigation
+
+| Area | Representative work | Original course units |
+|---|---|---|
+| [Machine Learning and Data Science](portfolio/01-ml-and-data-science/) | Regression, preprocessing, baseline comparison | Exploration Ex01–Ex02 |
+| [Computer Vision Fundamentals](portfolio/02-computer-vision-fundamentals/) | Facial landmarks, segmentation, masks, image transformation | Exploration Ex03–Ex04 |
+| [Natural Language Processing](portfolio/03-natural-language-processing/) | Sentiment classification, summarization, Transformer chatbot | Exploration Ex05–Ex07 |
+| [Deep Computer Vision](portfolio/04-deep-computer-vision/) | ResNet ablation, augmentation, Grad-CAM, SSD, U-Net/U-Net++, pose estimation | GoingDeeper GD01–GD09 |
+| [Generative Language Modeling](portfolio/05-generative-language-modeling/) | Subword tokenization and GPT-style dialogue modeling | MainQuest Quest01 |
+| [Team and Capstone Projects](portfolio/06-team-and-capstone-projects/) | Limited-data lung-image segmentation and MINI AIFFELTHON | MainQuest Quest02; external team repository |
+
+## Selected evidence
+
+- **Experimental comparison:** ResNet-50 versus PlainNet-50 ablation, with loss/accuracy interpretation and discussion of skip connections.
+- **Augmentation:** normalization, conventional augmentation, CutMix, and MixUp experiments with model save/reload workflows.
+- **Explainability and localization:** CAM/Grad-CAM feature maps, bounding-box correction, and IoU-based inspection.
+- **Detection and segmentation:** TFRecord/prior-box preparation, SSD face detection, U-Net/U-Net++ implementation, and an exploratory lung-segmentation extension.
+- **Natural language processing:** Korean text preprocessing, LSTM/Conv1D sentiment models, sequence-to-sequence attention, subword tokenization, and Transformer-based dialogue modeling.
+- **Research habits:** modularization, checkpointing, failure analysis, documented debugging, and peer code review.
+
+## Evidence and authorship boundaries
+
+- `Exploration/`, `GoingDeeper/`, and `MainQuest/` preserve the original course structure and history.
+- A completed notebook or repository presence does not by itself establish sole authorship.
+- Each featured project should identify the course context, provided baseline, individual changes, peer reviewer, data source, and limitations.
+- Team projects remain explicitly labeled as team work.
+- Empty templates and units whose contents have not been verified are not counted as completed projects.
+
+See:
+
+- [Curriculum map](docs/curriculum-map.md)
+- [Project evidence matrix](docs/project-evidence-matrix.md)
+- [Project README template](docs/project-readme-template.md)
+- [Repository provenance](docs/repository-provenance.md)
+
+## Relevance to medical-imaging research
+
+The strongest transferable skills are segmentation, explainability, controlled data splitting, error analysis, and reproducible experiment documentation. Applying these methods to clinical research still requires appropriate IRB/data governance, acquisition-aware quality control, leakage-safe validation, and independent clinical evaluation.
+
+## Data and privacy
+
+No patient-level clinical data should be committed to this repository. Course datasets remain subject to their original licenses and terms. Large datasets, checkpoints, API keys, local paths, and confidential material must remain outside version control.

--- a/docs/curriculum-map.md
+++ b/docs/curriculum-map.md
@@ -1,0 +1,42 @@
+# Curriculum Map
+
+This document maps the original AIFFEL folder structure to descriptive portfolio topics. Original paths are retained for provenance; the `portfolio/` folders provide the researcher-facing navigation layer.
+
+| Portfolio area | Public-facing topic | Original unit | Evidence status |
+|---|---|---|---|
+| Machine Learning and Data Science | Tabular regression foundations | `Exploration/Ex01` | Notebook and named peer review present |
+| Machine Learning and Data Science | House-price prediction / baseline modeling | `Exploration/Ex02` | Notebook and partial peer review present; baseline contribution should be clarified |
+| Computer Vision Fundamentals | Facial landmark augmentation | `Exploration/Ex03` | Notebook and named peer review present |
+| Computer Vision Fundamentals | Object segmentation and background effects | `Exploration/Ex04` | Notebook and named peer review present |
+| Natural Language Processing | Korean sentiment classification | `Exploration/Ex05` | Notebook and named peer review present |
+| Natural Language Processing | Abstractive text summarization | `Exploration/Ex06` | Notebook present; README is an unfilled template |
+| Natural Language Processing | Transformer chatbot | `Exploration/Ex07` | Notebook and named peer review present |
+| Deep Computer Vision | ResNet–PlainNet ablation | `GoingDeeper/GD01` | Notebook and named peer review present |
+| Deep Computer Vision | CutMix and MixUp experiments | `GoingDeeper/GD02` | Notebook and named peer review present |
+| Deep Computer Vision | CAM/Grad-CAM and localization | `GoingDeeper/GD03` | Notebook and named peer review present |
+| Deep Computer Vision | Unit title pending verification | `GoingDeeper/GD04` | README is an unfilled template; do not feature yet |
+| Deep Computer Vision | SSD face detection | `GoingDeeper/GD05` | Notebook and named peer review present |
+| Deep Computer Vision | Unit title pending verification | `GoingDeeper/GD06` | README is an unfilled template; do not feature yet |
+| Deep Computer Vision | U-Net/U-Net++ segmentation | `GoingDeeper/GD07` | Notebook and peer review present; coder-name typo requires correction |
+| Deep Computer Vision | SimpleBaseline pose estimation | `GoingDeeper/GD08` | Notebook and peer review present; coder-name typo requires correction |
+| Deep Computer Vision | Unit title pending verification | `GoingDeeper/GD09` | README is an unfilled template; do not feature yet |
+| Generative Language Modeling | GPT-style dialogue model | `MainQuest/Quest01` | Notebook evidence present; README is an unfilled template |
+| Team and Capstone Projects | Limited-data lung-image segmentation | `MainQuest/Quest02` | Notebook evidence present; README is an unfilled template |
+| Main Quest archive | Topic pending verification | `MainQuest/Quest03` | README is an unfilled template; do not feature yet |
+| Main Quest archive | Topic pending verification | `MainQuest/Quest04` | README is an unfilled template; do not feature yet |
+| Main Quest archive | Topic pending verification | `MainQuest/Quest05` | README is an unfilled template; do not feature yet |
+
+## Naming rule
+
+Use a descriptive portfolio name externally and retain the original AIFFEL track/unit in every project README:
+
+```text
+Portfolio title: ResNet–PlainNet Ablation Study
+Original curriculum: AIFFEL Research Program / GoingDeeper / GD01
+Category: Training project
+```
+
+## Completion rule
+
+A unit is listed as completed only when its executable notebook or code, result, and authorship/provenance are identifiable. A pre-created folder or peer-review template alone is not evidence of completion.
+

--- a/docs/project-evidence-matrix.md
+++ b/docs/project-evidence-matrix.md
@@ -1,0 +1,41 @@
+# Project Evidence Matrix
+
+This matrix controls what may be claimed in a CV, application, or public portfolio. It is intentionally conservative.
+
+| Unit | Evidence-supported description | Contribution label | Portfolio use | Remaining action |
+|---|---|---|---|---|
+| Ex01 | Tabular regression exercises; preprocessing, train/test split, and error metrics | Individual coursework with peer review | Foundation | Add dataset/license and concise result summary |
+| Ex02 | House-price prediction based substantially on provided baseline | Individual coursework / provided baseline | Archive or foundation | Document exactly what changed from baseline |
+| Ex03 | Facial landmark placement and transformation-aware image processing | Individual coursework with peer review | Selected | Add reproducible run instructions |
+| Ex04 | Object detection/segmentation, masks, background manipulation, and debugging | Individual coursework with peer review | Selected | Add data/model attribution |
+| Ex05 | Korean sentiment preprocessing and LSTM/Conv1D/GlobalMaxPooling comparisons | Individual coursework with peer review | Selected | Verify final metrics before quoting them |
+| Ex06 | Sequence-to-sequence summarization with attention | Coursework; README evidence incomplete | Supporting | Complete authorship and result summary |
+| Ex07 | Subword tokenization and encoder–decoder Transformer chatbot | Individual coursework with peer review | Selected | Add dataset/license and environment |
+| GD01 | ResNet-50 versus PlainNet-50 ablation and skip-connection interpretation | Individual coursework with peer review | Featured | Add exact reproducibility details |
+| GD02 | Normalization, augmentation, CutMix/MixUp, and model persistence | Individual coursework with peer review | Featured | Summarize controlled comparison |
+| GD03 | CAM/Grad-CAM visualization, localization correction, and IoU inspection | Individual coursework with peer review | Featured | Separate completed and exploratory extensions |
+| GD04 | Unverified unit | Unverified | Exclude | Inspect notebook and replace template README |
+| GD05 | TFRecord, prior boxes, SSD face detection, and score debugging | Individual coursework with peer review | Selected | Add model/data attribution |
+| GD06 | Unverified unit | Unverified | Exclude | Inspect notebook and replace template README |
+| GD07 | U-Net/U-Net++ implementation and exploratory lung-segmentation extension | Coursework with peer review | Featured after provenance correction | Correct coder-name typo; avoid clinical-performance claims |
+| GD08 | SimpleBaseline pose estimation and direct ResNet-block implementation | Coursework with peer review | Selected after provenance correction | Correct coder-name typo and document dataset |
+| GD09 | Unverified unit | Unverified | Exclude | Inspect notebook and replace template README |
+| MainQuest 01 | Subword preprocessing and GPT-style decoder-only dialogue model | Coursework; README evidence incomplete | Selected after documentation | Add contribution, dataset, result, and limitations |
+| MainQuest 02 | Limited-data lung-image segmentation and architecture comparison | Coursework; README evidence incomplete | Selected after documentation | Add contribution, split, metrics, and data provenance |
+| MainQuest 03–05 | No verified completion evidence in current README files | Unverified | Exclude | Inspect notebook contents before naming or claiming completion |
+
+## Claim levels
+
+- **Featured:** code, result, authorship, and peer-review evidence are present; still describe it as training.
+- **Selected:** useful technical evidence, but documentation or reproducibility needs improvement.
+- **Supporting/Foundation:** demonstrates breadth but should not occupy a pinned-project slot.
+- **Exclude:** do not describe as completed until evidence is added.
+
+## Prohibited claims
+
+- Clinically validated medical model
+- Completed external or multicenter validation through AIFFEL
+- Sole authorship of team or peer repositories
+- Production MLOps system
+- Performance values that have not been re-run and verified
+

--- a/docs/project-readme-template.md
+++ b/docs/project-readme-template.md
@@ -1,0 +1,55 @@
+# Project Title
+
+> **Category:** Training Project / Team Training Project  
+> **Original curriculum:** AIFFEL Research Program / Track / Unit  
+> **Status:** Completed / Partially completed / Documentation pending  
+> **My role:** One precise sentence
+
+## Problem
+
+What problem did the course project ask you to solve?
+
+## Course context and provenance
+
+- Course-provided notebook, baseline, model, or code:
+- Upstream source and license:
+- Team members or peer reviewer:
+- What I implemented or changed:
+
+## Data
+
+- Source and license:
+- Sample/unit of analysis:
+- Train/validation/test rule:
+- Data not included in this repository:
+
+## Methods
+
+Describe preprocessing, model, baseline, loss, optimizer, and experimental comparison.
+
+## Validation and results
+
+Report only re-run, verified results. State the split, metric, and comparison. Do not infer clinical performance from a course dataset.
+
+## Error and failure analysis
+
+Describe failed approaches, debugging, difficult cases, and what changed afterward.
+
+## Reproduction
+
+```bash
+# environment creation
+# data preparation
+# training or inference command
+```
+
+Record package versions, random seed, expected runtime, and hardware where relevant.
+
+## What I learned
+
+Explain the transferable concept or engineering practice rather than repeating the course objective.
+
+## Limitations and intended use
+
+State that the artifact is for education/research exploration and is not intended for clinical or production use unless independently validated.
+

--- a/docs/repository-provenance.md
+++ b/docs/repository-provenance.md
@@ -1,0 +1,22 @@
+# Repository Provenance
+
+## Canonical public portfolio
+
+`PeterYYong/AIFFEL_quest_rs` is the only AIFFEL repository intended for the public researcher portfolio.
+
+## Original course and peer-review archives
+
+The repositories `AIFFEL_quest_rs-1` through `AIFFEL_quest_rs-8` preserve course snapshots, peer-review targets, shared artifacts, or contributions by other participants. They are not treated as candidate-authored portfolio projects and should not be used as evidence of sole authorship.
+
+Before any later merge or archive operation:
+
+1. Compare file paths and hashes.
+2. Identify the notebook author, provided baseline, peer reviewer, and team contributors.
+3. Preserve unique review records and original commit history.
+4. Exclude large datasets, checkpoints, credentials, and restricted material.
+5. Move only clearly attributable candidate work into the curated navigation layer.
+
+## Preservation approach
+
+The current restructuring does not delete or relocate original notebooks. The `portfolio/` directory is a descriptive navigation layer that links to the original AIFFEL paths, allowing the original history and peer-review records to remain intact.
+

--- a/portfolio/01-ml-and-data-science/README.md
+++ b/portfolio/01-ml-and-data-science/README.md
@@ -1,0 +1,9 @@
+# Machine Learning and Data Science
+
+Foundational tabular modeling work from the AIFFEL `Exploration` track.
+
+- [Exploration Ex01](../../Exploration/Ex01): diabetes and bike-demand regression exercises, preprocessing, train/test splitting, and error metrics.
+- [Exploration Ex02](../../Exploration/Ex02): house-price prediction based substantially on a provided baseline; the individual delta requires clearer documentation.
+
+These are training projects. Dataset provenance, baseline attribution, and re-run metrics should be completed before detailed results are quoted.
+

--- a/portfolio/02-computer-vision-fundamentals/README.md
+++ b/portfolio/02-computer-vision-fundamentals/README.md
@@ -1,0 +1,9 @@
+# Computer Vision Fundamentals
+
+Image preprocessing, landmark placement, segmentation masks, and transformation experiments from the AIFFEL `Exploration` track.
+
+- [Exploration Ex03](../../Exploration/Ex03): facial landmark augmentation and transformation-aware placement, including failure handling.
+- [Exploration Ex04](../../Exploration/Ex04): object segmentation, mask construction, background effects, debugging, and additional image experiments.
+
+Both projects are retained as individual coursework with named peer-review evidence.
+

--- a/portfolio/03-natural-language-processing/README.md
+++ b/portfolio/03-natural-language-processing/README.md
@@ -1,0 +1,10 @@
+# Natural Language Processing
+
+Text preprocessing, sequence modeling, attention, and Transformer experiments from the AIFFEL `Exploration` track.
+
+- [Exploration Ex05](../../Exploration/Ex05): Korean sentiment classification using morphological preprocessing and LSTM/Conv1D/GlobalMaxPooling models.
+- [Exploration Ex06](../../Exploration/Ex06): abstractive text summarization with sequence-to-sequence attention; documentation remains incomplete.
+- [Exploration Ex07](../../Exploration/Ex07): subword tokenization and an encoder–decoder Transformer chatbot, including custom loss/checkpoint workflows.
+
+These projects demonstrate training breadth; they are not presented as independent NLP research.
+

--- a/portfolio/04-deep-computer-vision/README.md
+++ b/portfolio/04-deep-computer-vision/README.md
@@ -1,0 +1,13 @@
+# Deep Computer Vision
+
+Architecture comparison, augmentation, explainability, detection, segmentation, and pose-estimation work from the AIFFEL `GoingDeeper` track.
+
+- [GD01](../../GoingDeeper/GD01): ResNet-50 versus PlainNet-50 ablation.
+- [GD02](../../GoingDeeper/GD02): normalization, conventional augmentation, CutMix, and MixUp.
+- [GD03](../../GoingDeeper/GD03): CAM/Grad-CAM feature maps, localization correction, and IoU inspection.
+- [GD05](../../GoingDeeper/GD05): TFRecord/prior-box preparation and SSD face detection.
+- [GD07](../../GoingDeeper/GD07): U-Net/U-Net++ segmentation and an exploratory lung-segmentation extension.
+- [GD08](../../GoingDeeper/GD08): SimpleBaseline pose estimation and direct ResNet-block implementation.
+
+`GD04`, `GD06`, and `GD09` remain excluded from featured claims until their notebook contents and provenance are documented. The coder-name typos in `GD07` and `GD08` should also be corrected before those units are used externally.
+

--- a/portfolio/05-generative-language-modeling/README.md
+++ b/portfolio/05-generative-language-modeling/README.md
@@ -1,0 +1,6 @@
+# Generative Language Modeling
+
+- [MainQuest Quest01](../../MainQuest/Quest01): subword preprocessing and a GPT-style decoder-only dialogue model.
+
+The notebook provides implementation evidence, while the current project README remains an unfilled template. Contribution, dataset provenance, verified results, and limitations should be documented before the project is featured in an application.
+

--- a/portfolio/06-team-and-capstone-projects/README.md
+++ b/portfolio/06-team-and-capstone-projects/README.md
@@ -1,0 +1,7 @@
+# Team and Capstone Projects
+
+- [MainQuest Quest02](../../MainQuest/Quest02): limited-data lung-image segmentation and architecture comparison. This is course work; the current README requires a contribution, split, metric, and data-provenance summary.
+- [MINI AIFFELTHON — Traffic Light](https://github.com/PeterYYong/MA_TrafficLight): shared team training project by 황동주, 김영민, 윤수영, and 김용석. It should not be presented as sole-authored work; individual responsibilities remain to be documented.
+
+Projects in this section are included to document collaborative and capstone experience, not as independently validated research systems.
+


### PR DESCRIPTION
## What changed

- reframed the repository as a training portfolio rather than independent research
- added descriptive curriculum navigation while preserving original folders and history
- added a conservative evidence matrix, provenance rules, and a reusable project README template
- separated verified, supporting, incomplete, team, and unverified artifacts
- added topic-level navigation for ML, computer vision, NLP, generative modeling, and capstone work

## Safety and provenance

- no notebook was moved or deleted
- no unverified metric was added
- team/course/baseline boundaries are explicit
- incomplete units remain excluded from completed-project claims
- no patient-level clinical data are included

## Validation

- compared the branch against `main`
- re-read the key files from the remote branch
- checked relative links and original AIFFEL unit mappings